### PR TITLE
Make buildkit a flag

### DIFF
--- a/root.go
+++ b/root.go
@@ -66,10 +66,14 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.unbake.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
+		"config file (default is $HOME/.unbake.yaml)")
 
 	rootCmd.Flags().StringP("file", "f", "", "bake file to process")
 	_ = rootCmd.MarkFlagRequired("file")
+
+	rootCmd.Flags().BoolVarP(&buildKit, "buildkit", "b", false,
+		"prepend DOCKER_BUILDKIT=1 to commands")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/unbake.go
+++ b/unbake.go
@@ -34,7 +34,11 @@ func targetsToCommands(targets map[string]bake.Target) []string {
 	var result []string
 	for _, t := range targets {
 		for _, tag := range t.Tags {
-			var cmd = fmt.Sprintf("DOCKER_BUILDKIT=1 docker build -t %s -f %s ", tag, *t.Dockerfile)
+			var cmd string
+			if buildKit {
+				cmd += "DOCKER_BUILDKIT=1 "
+			}
+			cmd += fmt.Sprintf("docker build -t %s -f %s ", tag, *t.Dockerfile)
 			for k, v := range t.Args {
 				cmd += fmt.Sprintf("--build-arg %s=%s ", k, v)
 			}
@@ -44,3 +48,5 @@ func targetsToCommands(targets map[string]bake.Target) []string {
 	}
 	return result
 }
+
+var buildKit bool

--- a/unbake_test.go
+++ b/unbake_test.go
@@ -43,6 +43,42 @@ func TestBasicLoad(t *testing.T) {
 	}
 
 	var expect = map[string]struct{}{
+		"docker build -t foo -f docker/go_container.dockerfile --build-arg cmd=foo .": {},
+		"docker build -t bar -f docker/go_container.dockerfile --build-arg cmd=bar .": {},
+	}
+
+	var actual = make(map[string]struct{})
+	for _, val := range result {
+		actual[val] = struct{}{}
+	}
+
+	if !reflect.DeepEqual(expect, actual) {
+		t.Fatalf("command mismatch, expected:\n %v\n got:\n %v", expect, actual)
+	}
+}
+
+func TestLoadWithBuildKit(t *testing.T) {
+	buildKit = true
+	var testFile, err = createTestConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Remove(testFile); err != nil {
+			t.Fatalf("removing test file: %s", err)
+		}
+	}()
+
+	result, err := unbake(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result) != 2 {
+		t.Fatal("wrong number of command results")
+	}
+
+	var expect = map[string]struct{}{
 		"DOCKER_BUILDKIT=1 docker build -t foo -f docker/go_container.dockerfile --build-arg cmd=foo .": {},
 		"DOCKER_BUILDKIT=1 docker build -t bar -f docker/go_container.dockerfile --build-arg cmd=bar .": {},
 	}


### PR DESCRIPTION
Don't set the buildkit value by default. Instead, set it as a flag.