### PR TITLE
Add support for custom client configs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denisenkom/go-mssqldb v0.0.0-20190315220205-a8ed825ac853/go.mod h1:xN/JuLBIz4bjkxNmByTiV1IbhfnYb6oo99phBn4Eqhc=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/docker/buildx v0.2.2 h1:2jT/yMQoEO/JD/cKyu9N6Ts/iSmT3Z5GY+EQFfdPHnE=
-github.com/docker/buildx v0.2.2/go.mod h1:RcDWI9uwC42mfS9FI95TiJmffgecb09IP6Cs9zJpRXM=
 github.com/docker/buildx v0.3.0 h1:8AiJkrDexF9/WlTuPUIrTfoo/kuZWYalwWR/K9a1HDo=
 github.com/docker/buildx v0.3.0/go.mod h1:Cv7Wc7umcZakSyEnb3f+AL2llSyIUbfVc4/cXZHkkuM=
 github.com/docker/cli v0.0.0-20190321234815-f40f9c240ab0/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
@@ -134,11 +132,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1:MJG/KsmcqMwFAkh8mTnAwhyKoB+sTAnY4CACC110tbU=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
-github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.0.0-20160207214719-a0d98a5f2880/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c/go.mod h1:fHzc09UnyJyqyW+bFuq864eh+wC7dj65aXmXLRe5to0=
@@ -148,8 +143,6 @@ github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20180213033435-07191f837fed/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
-github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea h1:8jAXxWimXVprzB8T6UPtRc839vieK/m2LsvNU0aw5pA=
-github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea/go.mod h1:QMdK4dGB3YhEW2BmA1wgGpPYI3HZy/5gD705PXKUVSg=
 github.com/jinzhu/gorm v1.9.2/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
 github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.0.0/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=

--- a/root.go
+++ b/root.go
@@ -75,6 +75,9 @@ func init() {
 
 	rootCmd.Flags().BoolVarP(&buildKit, "buildkit", "b", false,
 		"prepend DOCKER_BUILDKIT=1 to commands")
+
+	rootCmd.Flags().StringVar(&dockerCfg, "docker-config", "",
+		"custom docker client config directory")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/unbake.go
+++ b/unbake.go
@@ -39,7 +39,11 @@ func targetsToCommands(targets map[string]bake.Target) []string {
 			if buildKit {
 				cmd += "DOCKER_BUILDKIT=1 "
 			}
-			cmd += fmt.Sprintf("docker build -t %s -f %s ", tag, *t.Dockerfile)
+			cmd += "docker "
+			if dockerCfg != "" {
+				cmd += fmt.Sprintf("--config=%s ", dockerCfg)
+			}
+			cmd += fmt.Sprintf("build -t %s -f %s ", tag, *t.Dockerfile)
 			for k, v := range t.Args {
 				cmd += fmt.Sprintf("--build-arg %s=%s ", k, v)
 			}
@@ -51,3 +55,4 @@ func targetsToCommands(targets map[string]bake.Target) []string {
 }
 
 var buildKit bool
+var dockerCfg string

--- a/unbake_test.go
+++ b/unbake_test.go
@@ -94,6 +94,43 @@ func TestLoadWithBuildKit(t *testing.T) {
 	}
 }
 
+func TestLoadWithCustomConfig(t *testing.T) {
+	buildKit = true
+	dockerCfg = "/path/to/config"
+	var testFile, err = createTestConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Remove(testFile); err != nil {
+			t.Fatalf("removing test file: %s", err)
+		}
+	}()
+
+	result, err := unbake(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result) != 2 {
+		t.Fatal("wrong number of command results")
+	}
+
+	var expect = map[string]struct{}{
+		"DOCKER_BUILDKIT=1 docker --config=/path/to/config build -t foo -f docker/go_container.dockerfile --build-arg cmd=foo .": {},
+		"DOCKER_BUILDKIT=1 docker --config=/path/to/config build -t bar -f docker/go_container.dockerfile --build-arg cmd=bar .": {},
+	}
+
+	var actual = make(map[string]struct{})
+	for _, val := range result {
+		actual[val] = struct{}{}
+	}
+
+	if !reflect.DeepEqual(expect, actual) {
+		t.Fatalf("command mismatch, expected:\n %v\n got:\n %v", expect, actual)
+	}
+}
+
 var testConfig = []byte(`
 group "default" {
   targets = ["foo", "bar"]


### PR DESCRIPTION
Add support for passing a custom config flag to the docker client as
part of the unbaked commands.

Resolves #15