### PR TITLE
Pin buildx to fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ requirement, making this a promising option for CI environments):
 ```
 docker run --rm -v$(pwd):/bake asonawalla/unbake /bin/unbake -f /bake/bake.hcl | sh
 ```
+
+## Compatibility
+Though upstream docker/buildx's high level build constructs are a WIP and buildx itself is listed as a "tech preview",
+this repository uses a forked and pinned version of buildx at asonawalla/buildx. Unbake will update with releases
+as the fork tracks upstream. That means that if you use asonawalla/buildx, it will reliably be compatible with
+asonawalla/unbake.

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 replace github.com/hashicorp/go-immutable-radix => github.com/tonistiigi/go-immutable-radix v0.0.0-20170803185627-826af9ccf0fe
 
 replace github.com/jaguilar/vt100 => github.com/tonistiigi/vt100 v0.0.0-20190402012908-ad4c4a574305
+
+replace github.com/docker/buildx => github.com/asonawalla/buildx v0.3.0


### PR DESCRIPTION
This gives us slightly stronger compatibility guarantees since the
upstream docker/buildx is listed as a tech demo and may not have a
stable API.